### PR TITLE
Merge pull request #4 from Kshitiz1403:fix/spotifydl-access-token

### DIFF
--- a/src/utils/spotify/trackService.ts
+++ b/src/utils/spotify/trackService.ts
@@ -38,7 +38,7 @@ const playlistToYT = async (playlistID: string): Promise<IPlaylist> => {
 };
 
 const spotifyToYT = async (spotifyURL: string) => {
-  if (playdl.is_expired()) playdl.refreshToken();
+  if (playdl.is_expired()) await playdl.refreshToken();
 
   const spotifyResponse = await playdl.spotify(spotifyURL);
 


### PR DESCRIPTION
fix(spotify-dl): access token regenerate on expire