### PR TITLE
Fix elapsed percentage calculation

### DIFF
--- a/src/utils/botMessage/formatters/elapsedDuration.ts
+++ b/src/utils/botMessage/formatters/elapsedDuration.ts
@@ -2,7 +2,7 @@ function elapsedDuration(durationElapsed: number, totalTime: number): string {
   const maxLength = 69; // noice
 
   const completedRatio = durationElapsed / totalTime;
-  const completedPercentage = Math.floor(completedRatio * 100);
+  const completedPercentage = Math.ceil(completedRatio * 100);
 
   const completed = Math.floor(completedRatio * maxLength);
   const template = `[${"-".repeat(completed)}${" ".repeat(


### PR DESCRIPTION
This pull request fixes an issue where the elapsed percentage would get stuck at 99 instead of 100. The calculation has been updated to use Math.ceil instead of Math.floor to ensure accurate rounding.